### PR TITLE
feat: enhance plugin installation experience

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
@@ -89,7 +89,7 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
         if ( project == this.project ) dispose();
 
         if ( !getPluginState().isOnboardingFinished() ) {
-            UserOnboarding.INSTANCE.finishOnBoarding();
+            UserOnboarding.INSTANCE.finishOnboarding();
             return;
         }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
@@ -88,6 +88,11 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
     public void projectClosing( @NotNull Project project ) {
         if ( project == this.project ) dispose();
 
+        if ( !getPluginState().isOnboardingFinished() ) {
+            UserOnboarding.INSTANCE.finishOnBoarding();
+            return;
+        }
+
         if ( !getPluginState().isSayonaraEnabled() ||
             areMultipleProjectsOpened() ||
             PluginInstallListener.Companion.isRunningUpdate() ) return;

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
@@ -38,4 +38,8 @@ object UserOnboarding {
         PluginManagerCore.getPlugin(PluginId.getId(WaifuMotivator.PLUGIN_ID))
             .toOptional()
             .map { it.version }
+
+    fun finishOnBoarding() {
+        WaifuMotivatorPluginState.getPluginState().isOnboardingFinished = true
+    }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
@@ -15,6 +15,7 @@ object UserOnboarding {
 
     fun attemptToPerformNewUpdateActions() {
         getNewVersion().ifPresent { newVersion ->
+            startOnboarding()
             WaifuMotivatorPluginState.getPluginState().version = newVersion
             ApplicationManager.getApplication().messageBus
                 .syncPublisher(UpdateAssetsListener.TOPIC)
@@ -39,7 +40,11 @@ object UserOnboarding {
             .toOptional()
             .map { it.version }
 
-    fun finishOnBoarding() {
+    private fun startOnboarding() {
+        WaifuMotivatorPluginState.getPluginState().isOnboardingFinished = false
+    }
+
+    fun finishOnboarding() {
         WaifuMotivatorPluginState.getPluginState().isOnboardingFinished = true
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -61,4 +61,6 @@ class WaifuMotivatorState {
     var preferredCharacters = ""
 
     var isShowMood = true
+
+    var isOnboardingFinished = false
 }


### PR DESCRIPTION
This PR addresses the Sayonara on a fresh install of the plugin.

Initially, I wanted to use `UserOnboarding#isNewVersion` but the version is already updated on the project opened, so we can't use it on project closed where Sayonara is triggered. So I opt-in adding a new plugin state.