### PR TITLE
feat: waifu log watcher

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -47,5 +47,10 @@
         <option name="TAB_SIZE" value="2" />
       </indentOptions>
     </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
   </code_scheme>
 </component>

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertConfiguration.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertConfiguration.kt
@@ -5,3 +5,11 @@ data class AlertConfiguration(
     val isDisplayNotificationEnabled: Boolean = false,
     val isSoundAlertEnabled: Boolean = false
 )
+
+object AlertConfigurationAllEnabled {
+    fun create() = AlertConfiguration(
+        isAlertEnabled = true,
+        isDisplayNotificationEnabled = true,
+        isSoundAlertEnabled = true
+    )
+}

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertConfiguration.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertConfiguration.kt
@@ -4,12 +4,13 @@ data class AlertConfiguration(
     val isAlertEnabled: Boolean = false,
     val isDisplayNotificationEnabled: Boolean = false,
     val isSoundAlertEnabled: Boolean = false
-)
-
-object AlertConfigurationAllEnabled {
-    fun create() = AlertConfiguration(
-        isAlertEnabled = true,
-        isDisplayNotificationEnabled = true,
-        isSoundAlertEnabled = true
-    )
+) {
+    companion object {
+        fun allEnabled(): AlertConfiguration =
+            AlertConfiguration(
+                isAlertEnabled = true,
+                isDisplayNotificationEnabled = true,
+                isSoundAlertEnabled = true
+            )
+    }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
@@ -3,7 +3,7 @@ package zd.zero.waifu.motivator.plugin.integrations
 import com.intellij.execution.filters.ConsoleFilterProvider
 import com.intellij.execution.filters.Filter
 import com.intellij.openapi.project.Project
-import zd.zero.waifu.motivator.plugin.alert.AlertConfigurationAllEnabled
+import zd.zero.waifu.motivator.plugin.alert.AlertConfiguration
 import zd.zero.waifu.motivator.plugin.assets.WaifuAssetCategory
 import zd.zero.waifu.motivator.plugin.motivation.MotivationFactory
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
@@ -33,7 +33,7 @@ class WaifuConsoleFilterProvider : ConsoleFilterProvider {
                             MotivationEventCategory.POSITIVE,
                             "Waifu Log Watcher Event",
                             project
-                        ) { AlertConfigurationAllEnabled.create() },
+                        ) { AlertConfiguration.allEnabled() },
                         WaifuAssetCategory.ACKNOWLEDGEMENT,
                         WaifuAssetCategory.CELEBRATION,
                         WaifuAssetCategory.HAPPY,

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
@@ -1,0 +1,52 @@
+package zd.zero.waifu.motivator.plugin.integrations
+
+import com.intellij.execution.filters.ConsoleFilterProvider
+import com.intellij.execution.filters.Filter
+import com.intellij.openapi.project.Project
+import zd.zero.waifu.motivator.plugin.alert.AlertConfigurationAllEnabled
+import zd.zero.waifu.motivator.plugin.assets.WaifuAssetCategory
+import zd.zero.waifu.motivator.plugin.motivation.MotivationFactory
+import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
+import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEventCategory
+import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvents
+import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState.getPluginState
+
+class WaifuConsoleFilterProvider : ConsoleFilterProvider {
+
+    private var prevLength: Int = Int.MAX_VALUE
+
+    private var alertShown = false
+
+    override fun getDefaultFilters(project: Project): Array<Filter> = when {
+        getPluginState().isLogWatcherEnabled -> arrayOf(
+            Filter { line, entireLength ->
+                val newConsole = entireLength < prevLength
+                if (newConsole) alertShown = false
+
+                val pluginState = getPluginState()
+                if (alertShown.not() && pluginState.logWatcherKeyword.isNotEmpty() &&
+                    line.contains(pluginState.logWatcherKeyword, ignoreCase = pluginState.isLogWatcherCaseSensitivityIgnored)
+                ) {
+                    MotivationFactory.showUntitledMotivationEventFromCategories(
+                        MotivationEvent(
+                            MotivationEvents.MISC,
+                            MotivationEventCategory.POSITIVE,
+                            "Waifu Log Watcher Event",
+                            project
+                        ) { AlertConfigurationAllEnabled.create() },
+                        WaifuAssetCategory.ACKNOWLEDGEMENT,
+                        WaifuAssetCategory.CELEBRATION,
+                        WaifuAssetCategory.HAPPY,
+                        WaifuAssetCategory.SMUG
+                    )
+
+                    alertShown = true
+                }
+
+                prevLength = entireLength
+                return@Filter null
+            }
+        )
+        else -> Filter.EMPTY_ARRAY
+    }
+}

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/WaifuConsoleFilterProvider.kt
@@ -25,7 +25,7 @@ class WaifuConsoleFilterProvider : ConsoleFilterProvider {
 
                 val pluginState = getPluginState()
                 if (alertShown.not() && pluginState.logWatcherKeyword.isNotEmpty() &&
-                    line.contains(pluginState.logWatcherKeyword, ignoreCase = pluginState.isLogWatcherCaseSensitivityIgnored)
+                    line.contains(pluginState.logWatcherKeyword, ignoreCase = pluginState.isLogWatcherCaseIgnored)
                 ) {
                     MotivationFactory.showUntitledMotivationEventFromCategories(
                         MotivationEvent(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -145,6 +145,68 @@
               </component>
             </children>
           </grid>
+          <grid id="21b3" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <tabbedpane title-resource-bundle="messages/MessageBundle" title-key="settings.tab.log.watcher"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <hspacer id="1fa9d">
+                <constraints>
+                  <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </hspacer>
+              <component id="72028" class="javax.swing.JCheckBox" binding="ignoreCaseSensitivityCheckBox" default-binding="true">
+                <constraints>
+                  <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <enabled value="true"/>
+                  <text resource-bundle="messages/MessageBundle" key="settings.log.watcher.ignore.case.sensitivity"/>
+                </properties>
+              </component>
+              <vspacer id="7c2ee">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="2" hsize-policy="1" anchor="1" fill="0" indent="0" use-parent-layout="false">
+                    <preferred-size width="11" height="5"/>
+                  </grid>
+                </constraints>
+              </vspacer>
+              <vspacer id="6ee99">
+                <constraints>
+                  <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+                </constraints>
+              </vspacer>
+              <component id="be9fd" class="javax.swing.JTextField" binding="logWatcherKeywordTextField">
+                <constraints>
+                  <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false">
+                    <preferred-size width="150" height="-1"/>
+                  </grid>
+                </constraints>
+                <properties>
+                  <enabled value="true"/>
+                </properties>
+              </component>
+              <component id="c1e09" class="javax.swing.JCheckBox" binding="enableLogWatcherCheckBox">
+                <constraints>
+                  <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="messages/MessageBundle" key="settings.log.watcher.watch.logs"/>
+                </properties>
+              </component>
+              <component id="1558" class="javax.swing.JLabel">
+                <constraints>
+                  <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="9" fill="0" indent="1" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="messages/MessageBundle" key="settings.log.watcher.header"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
           <grid id="5245b" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -158,7 +158,7 @@
                   <grid row="2" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
-              <component id="72028" class="javax.swing.JCheckBox" binding="ignoreCaseSensitivityCheckBox" default-binding="true">
+              <component id="72028" class="javax.swing.JCheckBox" binding="ignoreCaseCheckBox">
                 <constraints>
                   <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
                 </constraints>

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -27,6 +27,7 @@ import javax.swing.JPanel;
 import javax.swing.JSlider;
 import javax.swing.JSpinner;
 import javax.swing.JTabbedPane;
+import javax.swing.JTextField;
 import javax.swing.ListModel;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
@@ -92,6 +93,12 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
     private JCheckBox showStatusBarIcon;
 
+    private JCheckBox ignoreCaseSensitivityCheckBox;
+
+    private JTextField logWatcherKeywordTextField;
+
+    private JCheckBox enableLogWatcherCheckBox;
+
     private ListTableModel<Integer> exitCodeListModel;
 
     public WaifuMotivatorSettingsPage() {
@@ -118,6 +125,11 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         allowFrustrationCheckBox.addActionListener( e -> {
             frustrationProbabilitySlider.setEnabled(allowFrustrationCheckBox.isSelected());
             eventsBeforeFrustrationSpinner.setEnabled(allowFrustrationCheckBox.isSelected());
+        } );
+
+        enableLogWatcherCheckBox.addActionListener( e -> {
+            ignoreCaseSensitivityCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
+            logWatcherKeywordTextField.setEnabled( enableLogWatcherCheckBox.isSelected() );
         } );
 
         frustrationProbabilitySlider.setForeground( UIUtil.getContextHelpForeground() );
@@ -153,6 +165,9 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
                 enableSayonara.isSelected() != this.state.isSayonaraEnabled() ||
                 !getPreferredCharacters().equals( this.state.getPreferredCharacters() ) ||
                 showStatusBarIcon.isSelected() != this.state.isShowMood() ||
+                enableLogWatcherCheckBox.isSelected() != this.state.isLogWatcherEnabled() ||
+                ignoreCaseSensitivityCheckBox.isSelected() != this.state.isLogWatcherCaseSensitivityIgnored() ||
+                !logWatcherKeywordTextField.getText().equals( this.state.getLogWatcherKeyword())  ||
                 exitCodesChanged;
     }
 
@@ -202,6 +217,9 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         );
         this.state.setPreferredCharacters( getPreferredCharacters() );
         this.state.setShowMood( showStatusBarIcon.isSelected() );
+        this.state.setLogWatcherEnabled( enableLogWatcherCheckBox.isSelected() );
+        this.state.setLogWatcherCaseSensitivityIgnored( ignoreCaseSensitivityCheckBox.isSelected() );
+        this.state.setLogWatcherKeyword( logWatcherKeywordTextField.getText() );
 
         // updates the Tip of the Day setting
         GeneralSettings.getInstance().setShowTipsOnStartup( !enableWaifuOfTheDay.isSelected() );
@@ -238,12 +256,22 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         this.enableIdleSoundCheckBox.setSelected( this.state.isIdleSoundEnabled() );
         this.enableTaskEventNotificationsCheckBox.setSelected( this.state.isTaskMotivationEnabled() );
         this.enableTaskEventSoundsCheckBox.setSelected( this.state.isTaskSoundEnabled() );
-        this.allowFrustrationCheckBox.setSelected( this.state.isAllowFrustration() );
-        this.eventsBeforeFrustrationSpinner.setValue( this.state.getEventsBeforeFrustration() );
-        this.frustrationProbabilitySlider.setValue( this.state.getProbabilityOfFrustration() );
         this.enableExitCodeNotifications.setSelected( this.state.isExitCodeNotificationEnabled() );
         this.enableExitCodeSound.setSelected( this.state.isExitCodeSoundEnabled() );
         this.showStatusBarIcon.setSelected( this.state.isShowMood() );
+
+        this.allowFrustrationCheckBox.setSelected( this.state.isAllowFrustration() );
+        this.eventsBeforeFrustrationSpinner.setValue( this.state.getEventsBeforeFrustration() );
+        this.eventsBeforeFrustrationSpinner.setEnabled( allowFrustrationCheckBox.isSelected() );
+        this.frustrationProbabilitySlider.setValue( this.state.getProbabilityOfFrustration() );
+        this.frustrationProbabilitySlider.setEnabled( allowFrustrationCheckBox.isSelected() );
+
+        this.enableLogWatcherCheckBox.setSelected( this.state.isLogWatcherEnabled() );
+        this.ignoreCaseSensitivityCheckBox.setSelected( this.state.isLogWatcherCaseSensitivityIgnored() );
+        this.ignoreCaseSensitivityCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
+        this.logWatcherKeywordTextField.setText( this.state.getLogWatcherKeyword() );
+        this.logWatcherKeywordTextField.setEnabled( enableLogWatcherCheckBox.isSelected() );
+
         initializeExitCodes();
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -93,7 +93,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
     private JCheckBox showStatusBarIcon;
 
-    private JCheckBox ignoreCaseSensitivityCheckBox;
+    private JCheckBox ignoreCaseCheckBox;
 
     private JTextField logWatcherKeywordTextField;
 
@@ -128,7 +128,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         } );
 
         enableLogWatcherCheckBox.addActionListener( e -> {
-            ignoreCaseSensitivityCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
+            ignoreCaseCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
             logWatcherKeywordTextField.setEnabled( enableLogWatcherCheckBox.isSelected() );
         } );
 
@@ -166,7 +166,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
                 !getPreferredCharacters().equals( this.state.getPreferredCharacters() ) ||
                 showStatusBarIcon.isSelected() != this.state.isShowMood() ||
                 enableLogWatcherCheckBox.isSelected() != this.state.isLogWatcherEnabled() ||
-                ignoreCaseSensitivityCheckBox.isSelected() != this.state.isLogWatcherCaseSensitivityIgnored() ||
+                ignoreCaseCheckBox.isSelected() != this.state.isLogWatcherCaseIgnored() ||
                 !logWatcherKeywordTextField.getText().equals( this.state.getLogWatcherKeyword())  ||
                 exitCodesChanged;
     }
@@ -218,7 +218,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         this.state.setPreferredCharacters( getPreferredCharacters() );
         this.state.setShowMood( showStatusBarIcon.isSelected() );
         this.state.setLogWatcherEnabled( enableLogWatcherCheckBox.isSelected() );
-        this.state.setLogWatcherCaseSensitivityIgnored( ignoreCaseSensitivityCheckBox.isSelected() );
+        this.state.setLogWatcherCaseIgnored( ignoreCaseCheckBox.isSelected() );
         this.state.setLogWatcherKeyword( logWatcherKeywordTextField.getText() );
 
         // updates the Tip of the Day setting
@@ -267,8 +267,8 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         this.frustrationProbabilitySlider.setEnabled( allowFrustrationCheckBox.isSelected() );
 
         this.enableLogWatcherCheckBox.setSelected( this.state.isLogWatcherEnabled() );
-        this.ignoreCaseSensitivityCheckBox.setSelected( this.state.isLogWatcherCaseSensitivityIgnored() );
-        this.ignoreCaseSensitivityCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
+        this.ignoreCaseCheckBox.setSelected( this.state.isLogWatcherCaseIgnored() );
+        this.ignoreCaseCheckBox.setEnabled( enableLogWatcherCheckBox.isSelected() );
         this.logWatcherKeywordTextField.setText( this.state.getLogWatcherKeyword() );
         this.logWatcherKeywordTextField.setEnabled( enableLogWatcherCheckBox.isSelected() );
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -64,7 +64,7 @@ class WaifuMotivatorState {
 
     var isLogWatcherEnabled = false
 
-    var isLogWatcherCaseSensitivityIgnored = true
+    var isLogWatcherCaseIgnored = true
 
     var logWatcherKeyword = ""
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -61,4 +61,10 @@ class WaifuMotivatorState {
     var preferredCharacters = ""
 
     var isShowMood = true
+
+    var isLogWatcherEnabled = false
+
+    var isLogWatcherCaseSensitivityIgnored = true
+
+    var logWatcherKeyword = ""
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -20,6 +20,7 @@
       serviceImplementation="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState"/>
     <applicationService serviceImplementation="zd.zero.waifu.motivator.plugin.service.ApplicationService"/>
     <applicationService serviceImplementation="zd.zero.waifu.motivator.plugin.service.WaifuGatekeeper"/>
+    <consoleFilterProvider implementation="zd.zero.waifu.motivator.plugin.integrations.WaifuConsoleFilterProvider"/>
     <errorHandler
       id="7111f9b9-f252-483e-9496-72d649347b6d"
       implementation="zd.zero.waifu.motivator.plugin.integrations.ErrorReporter"/>

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -26,6 +26,11 @@ settings.sound.on.motivate.me.tooltip=Plays a sound whenever 'Motivate Me' actio
 ### Preferences
 settings.preferences.preferred.character.label=Preferred Characters
 
+## Log Watcher
+settings.tab.log.watcher=Log Watcher
+settings.log.watcher.watch.logs=Watch Logs
+settings.log.watcher.ignore.case.sensitivity=Ignore case sensitivity
+settings.log.watcher.header=I'll watch the logs for you senpai!
 
 ## Personality
 settings.tab.personality=Personality

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -29,7 +29,7 @@ settings.preferences.preferred.character.label=Preferred Characters
 ## Log Watcher
 settings.tab.log.watcher=Log Watcher
 settings.log.watcher.watch.logs=Watch Logs
-settings.log.watcher.ignore.case.sensitivity=Ignore case sensitivity
+settings.log.watcher.ignore.case.sensitivity=Ignore case
 settings.log.watcher.header=I'll watch the logs for you senpai!
 
 ## Personality

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -30,7 +30,7 @@ settings.preferences.preferred.character.label=Preferred Characters
 settings.tab.log.watcher=Log Watcher
 settings.log.watcher.watch.logs=Watch Logs
 settings.log.watcher.ignore.case.sensitivity=Ignore case
-settings.log.watcher.header=I'll watch the logs for you senpai!
+settings.log.watcher.header=I'll watch the logs for you senpai! (๑•̀ㅂ•́)ง✧
 
 ## Personality
 settings.tab.personality=Personality


### PR DESCRIPTION
This PR implements watching of logs by keyword and triggers an alert once it's present in the runtime logs. 

## Demo
![demo](https://user-images.githubusercontent.com/21978370/97777668-ba5e5000-1bac-11eb-9e13-5fa71b8bc259.gif)

## Settings
<img width="628" alt="Screen Shot 2020-10-31 at 19 11 15" src="https://user-images.githubusercontent.com/21978370/97777691-e11c8680-1bac-11eb-8ce6-0a2f6fd101aa.png">

I planned to add this to `Events` tab but this would always be changed by the users so it was added at the second tab, I also plan to enhance this into something more intuitive, like adding action and make it a list of keywords where any keywords present in logs would trigger an alert, and more intuitive if we can select from the logs and add it to the list. But for now, one keyword should suffice the use cases.

Some of the use cases:
* Debugging - Most developers debug with classic `System.out.println()`, `console.log()`, and whatnot, these may not be the best debugging tool but it is one of the best ;). For instance, you've printed a log `hacker: I'm in` and add this keyword for waifu to watch and do your stuff without constantly checking the logs 😎
* Standby startup - There are large applications where the startup time takes almost a minute (e.g. large Spring Boot application) where only logs state if it finished starting.