### PR TITLE
chore: organization migration

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           java-version: 11
       - name: Setting up environment
-        uses: Unthrottled/wmp-env-action@v1.0.0
+        uses: waifu-motivator/wmp-env-action@v1.0.0
         with:
           release-type: non-prod
       - run: ./ciScripts/buildPlugin.sh


### PR DESCRIPTION
I figured I'd get a jump start on this, I think it should still work without these changes because GitHub should redirect to the actual location.

So I'll leave this in draft for now. Do you think we should also include the documentation updates?

Relevant issue #270 