### PR TITLE
docs: update links to organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 <!--suppress HtmlDeprecatedAttribute, HtmlRequiredAltAttribute -->
 <p align="center">
-    <a href="https://github.com/zd-zero/waifu-motivator-plugin/actions"><img src="https://github.com/zd-zero/waifu-motivator-plugin/workflows/Java%20CI/badge.svg"></a>
+    <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/actions"><img src="https://github.com/waifu-motivator/waifu-motivator-plugin/workflows/Java%20CI/badge.svg"></a>
   <a href="https://plugins.jetbrains.com/plugin/13381-waifu-motivator"><img alt="JetBrains IntelliJ Plugins" src="https://img.shields.io/jetbrains/plugin/v/13381-waifu-motivator"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/github/license/zd-zero/waifu-motivator-plugin"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/waifu-motivator/waifu-motivator-plugin"></a>
 </p>
 
 <p align="center">

--- a/buildSrc/src/main/kotlin/CreateReleaseNotes.kt
+++ b/buildSrc/src/main/kotlin/CreateReleaseNotes.kt
@@ -22,7 +22,7 @@ open class CreateReleaseNotes : DefaultTask() {
             ))
             it.write("""
 
-For more information please [see the changelog](https://github.com/zd-zero/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md).""")
+For more information please [see the changelog](https://github.com/waifu-motivator/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md).""")
         }
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,56 +1,56 @@
 # Changelog
 
-## [v1.3](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.3)
+## [v1.3](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.3)
 #### 27/09/2020
 
 ✨ Features:
 
-* [WMP-190](https://github.com/zd-zero/waifu-motivator-plugin/issues/190) Organized settings menu.
-* [WMP-155](https://github.com/zd-zero/waifu-motivator-plugin/issues/155) When any executed process through the IDE fails with an un-allowed exit code then you get a motivation event.
-* [WMP-194](https://github.com/zd-zero/waifu-motivator-plugin/issues/194) Can trigger a manual update of the list of motivation assets from the remote source.
-* [WMP-182](https://github.com/zd-zero/waifu-motivator-plugin/issues/182) Added configurable personality to your virtual companion.
-* [WMP-159](https://github.com/zd-zero/waifu-motivator-plugin/issues/159) Plugin can be used offline now.
-* [WMP-157](https://github.com/zd-zero/waifu-motivator-plugin/issues/157) `Motivate Me` now uses visual notifications.
-* [WMP-133](https://github.com/zd-zero/waifu-motivator-plugin/issues/133) When your code fails to build you'll get a `Surprised` or `Disapointed` event. The next time that your build succeeds, then you'll get a `Celebration` or `Smug` event.
-* [WMP-154](https://github.com/zd-zero/waifu-motivator-plugin/issues/154) When the user's IDE remains idle for a configured amount of time (defaults to 5 minutes) then the plugin will display a bored/waiting anime girl.
+* [WMP-190](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/190) Organized settings menu.
+* [WMP-155](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/155) When any executed process through the IDE fails with an un-allowed exit code then you get a motivation event.
+* [WMP-194](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/194) Can trigger a manual update of the list of motivation assets from the remote source.
+* [WMP-182](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/182) Added configurable personality to your virtual companion.
+* [WMP-159](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/159) Plugin can be used offline now.
+* [WMP-157](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/157) `Motivate Me` now uses visual notifications.
+* [WMP-133](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/133) When your code fails to build you'll get a `Surprised` or `Disapointed` event. The next time that your build succeeds, then you'll get a `Celebration` or `Smug` event.
+* [WMP-154](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/154) When the user's IDE remains idle for a configured amount of time (defaults to 5 minutes) then the plugin will display a bored/waiting anime girl.
 
 🐛 Bug Fixes:
 
-* Fixed [WMP-153](https://github.com/zd-zero/waifu-motivator-plugin/issues/153) Successful test runs with ignored tests now emit success motivation events.
-* Fixed [WMP-178](https://github.com/zd-zero/waifu-motivator-plugin/issues/178) Plugin actions can now be used while IDE is indexing.
-* Fixed [WMP-186](https://github.com/zd-zero/waifu-motivator-plugin/issues/186) Can close projects before they are initialized.
-* Fixed [WMP-198](https://github.com/zd-zero/waifu-motivator-plugin/issues/198) Enabled plugin to work without full IDE restart.
-* Fixed [WMP-209](https://github.com/zd-zero/waifu-motivator-plugin/issues/209) Waifu of the Day colors should come from theme look and feel
-* Fixed [WMP-167](https://github.com/zd-zero/waifu-motivator-plugin/issues/167) Sound player runtime exception
+* Fixed [WMP-153](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/153) Successful test runs with ignored tests now emit success motivation events.
+* Fixed [WMP-178](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/178) Plugin actions can now be used while IDE is indexing.
+* Fixed [WMP-186](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/186) Can close projects before they are initialized.
+* Fixed [WMP-198](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/198) Enabled plugin to work without full IDE restart.
+* Fixed [WMP-209](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/209) Waifu of the Day colors should come from theme look and feel
+* Fixed [WMP-167](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/167) Sound player runtime exception
 
 
-## [v1.2](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.2)
+## [v1.2](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.2)
 #### 21/08/2020
 ✨ Features:
 
-* [WMP-097](https://github.com/zd-zero/waifu-motivator-plugin/issues/97) Ability to disable 'Motivate Me' notification
-* [WMP-080](https://github.com/zd-zero/waifu-motivator-plugin/issues/80) Improvements on toolbar menu
-* [WMP-103](https://github.com/zd-zero/waifu-motivator-plugin/issues/103) Ability to enable 'Do Not Disturb' mode on different viewing modes
-* [WMP-102](https://github.com/zd-zero/waifu-motivator-plugin/issues/102) Welcome dialog for newly installed plugin or new version
-* [WMP-100](https://github.com/zd-zero/waifu-motivator-plugin/issues/100) Add images associated to the alert notification
+* [WMP-097](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/97) Ability to disable 'Motivate Me' notification
+* [WMP-080](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/80) Improvements on toolbar menu
+* [WMP-103](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/103) Ability to enable 'Do Not Disturb' mode on different viewing modes
+* [WMP-102](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/102) Welcome dialog for newly installed plugin or new version
+* [WMP-100](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/100) Add images associated to the alert notification
 
 🐛 Bug fix:
 
-* Fix [WMP-110](https://github.com/zd-zero/waifu-motivator-plugin/issues/110) Waifu unit tester executes multiple times
-* Fix [WMP-112](https://github.com/zd-zero/waifu-motivator-plugin/issues/112) Multiple different startup sounds
-* Fix [WMP-124](https://github.com/zd-zero/waifu-motivator-plugin/issues/124) Multiple test notifications
-* Fix [WMP-144](https://github.com/zd-zero/waifu-motivator-plugin/issues/144) Cancelled tests registers as passed event
+* Fix [WMP-110](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/110) Waifu unit tester executes multiple times
+* Fix [WMP-112](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/112) Multiple different startup sounds
+* Fix [WMP-124](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/124) Multiple test notifications
+* Fix [WMP-144](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/144) Cancelled tests registers as passed event
 
-## [v1.1.2](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.1.2)
+## [v1.1.2](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.1.2)
 #### 24/04/20
 * Fix: WMP-083 Plugin state AssertionError
 * Fix: WMP-084 Webstorm 2020.1 NoClassDefFoundError
 
-## [v1.1.1](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.1.1)
+## [v1.1.1](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.1.1)
 #### 18/04/20
 * Fix: WMP-075 No image for Nejire Hado for Waifu of the Day
 
-## [v1.1](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.1)
+## [v1.1](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.1)
 #### 12/04/20
 * WMP-073 Properly style Waifu of the Day based on theme
 * WMP-069 Add settings navigation menu on Plugin toolbar menu
@@ -65,7 +65,7 @@
 * WMP-051 Include more assets for waifu of the day and events
 <details>
   <summary>Waifu of The Day</summary>
-  
+
     * Update Aqua image
     * Shinobu Kocho
     * Mitsuri Kanroji
@@ -93,7 +93,7 @@
 
 <details>
   <summary>Alert Assets</summary>
-  
+
     * Nyaaan
     * Wwwwwwaaaaaaaaaaaaaaaaaaaaah
     * Wwwwaaaaaooowww
@@ -101,14 +101,14 @@
 </details>
 
 
-## [v1.0.1](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.0.1)
+## [v1.0.1](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.0.1)
 #### 01/01/20
 * Add more assets for Waifu of the Day
 * WMP-039 asset provider not properly categorizing on the next invocation
 * WMP-041 update images for dark theme
 * WMP-042 resolve sound stopping when the alert is expired
 
-## [v1.0](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.0)
+## [v1.0](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v1.0)
 #### 30/12/19
 * WMP-008 waifu of the day
 * WMP-022 random motivations on all alerts

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
@@ -25,13 +25,13 @@ val UPDATE_MESSAGE: String =
         <li>Re-organized settings menu</li>
         <li>Fixed various bugs.</li>
       </ul>
-      <br>Please see the <a href="https://github.com/zd-zero/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md">changelog</a> for more details.
+      <br>Please see the <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md">changelog</a> for more details.
       <br><br>
       Is your Waifu missing?<br>
-      Make a request for her to be featured in the <a href="https://github.com/zd-zero/waifu-motivator-plugin/projects/3">Waifu of the Day!</a>
+      Make a request for her to be featured in the <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/projects/3">Waifu of the Day!</a>
       <br><br>
       Want more of your Waifu?<br>
-      Make a request for <a href="https://github.com/zd-zero/waifu-motivator-plugin/projects/3">more assets of your Waifu!</a>
+      Make a request for <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/projects/2">more assets of your Waifu!</a>
     """.trimIndent()
 
 object UpdateNotification {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
-<idea-plugin url="https://github.com/zd-zero/waifu-motivator-plugin">
+<idea-plugin url="https://github.com/waifu-motivator/waifu-motivator-plugin">
   <id>zd.zero.waifu-motivator-plugin</id>
   <name>Waifu Motivator</name>
-  <vendor email="zaerald.zd@gmail.com" url="https://github.com/zd-zero">zd-zero</vendor>
+  <vendor email="zaerald.zd@gmail.com" url="https://github.com/zaerald">zaerald</vendor>
 
   <description><![CDATA[
         Open Sourced <i>Waifu</i> Motivator Plugin to help boost your motivation while coding!


### PR DESCRIPTION
This PR updates the base links to point to the new organization URL `https://github.com/waifu-motivator/`.

Resolves #270 