### PR TITLE
fix: waifu alert awareness

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/WaifuMotivation.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/WaifuMotivation.java
@@ -1,7 +1,5 @@
 package zd.zero.waifu.motivator.plugin.motivation;
 
-import com.intellij.notification.Notification;
-
 public interface WaifuMotivation {
 
     boolean isDisplayNotificationEnabled();
@@ -16,9 +14,12 @@ public interface WaifuMotivation {
 
     boolean isDistractionAllowed();
 
-    void onAlertClosed( Notification notification );
+    boolean isNotificationShowing();
+
+    void closeNotification();
 
     void motivate();
 
     WaifuMotivation setListener( MotivationListener motivationListener);
+
 }


### PR DESCRIPTION
This PR ensures that only 1 alert is showing on the platform. As we're now using a factory for displaying alerts, I opt-in utilizing the single instance instead of creating a singleton class that has more cons.