### PR TITLE
Constrain grouped assets to group.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ intellij {
 
     if ("DOKI" == System.getenv("DEV_ENV")) {
         setPlugins(
-            'io.acari.DDLCTheme:11.0.0'
+            'io.acari.DDLCTheme:11.3.1'
         )
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetService.kt
@@ -19,10 +19,21 @@ object TextAssetService {
         ConcurrentHashMap()
     private val random = Random(System.currentTimeMillis())
 
-    fun pickRandomAssetByCategory(waifuAssetCategory: WaifuAssetCategory): Optional<TextualMotivationAsset> =
+    fun pickRandomAssetByCategory(
+        waifuAssetCategory: WaifuAssetCategory
+    ): Optional<TextualMotivationAsset> =
         fetchListOfTextAssets(waifuAssetCategory)
             .map {
                 it.random(random)
+            }
+
+    fun getRandomUngroupedAssetByCategory(
+        category: WaifuAssetCategory
+    ): Optional<TextualMotivationAsset> =
+        fetchListOfTextAssets(category)
+            .map { textAssets ->
+                textAssets.filter { it.groupId == null }
+                    .random(random)
             }
 
     fun getAssetByGroupId(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -78,8 +78,8 @@ object VisualMotivationAssetProvider {
                     }.map { it.toOptional() } // todo: replace with `or` when on jre 11+
                     .orElseGet {
                         allOf(
-                            TextAssetService.pickRandomAssetByCategory(category),
-                            AudibleAssetDefinitionService.getRandomAssetByCategory(category)
+                            TextAssetService.getRandomUngroupedAssetByCategory(category),
+                            AudibleAssetDefinitionService.getRandomUngroupedAssetByCategory(category)
                         ).map(assetBundler)
                     }
             }

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProviderTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProviderTest.kt
@@ -78,11 +78,11 @@ class VisualMotivationAssetProviderTest {
 
     @Test
     fun `createAssetByCategory should return expected motivation when all assets resolve`() {
-        every { TextAssetService.pickRandomAssetByCategory(WaifuAssetCategory.CELEBRATION) } returns
+        every { TextAssetService.getRandomUngroupedAssetByCategory(WaifuAssetCategory.CELEBRATION) } returns
             TextualMotivationAsset("Just Monika").toOptional()
         every { VisualAssetDefinitionService.getRandomAssetByCategory(WaifuAssetCategory.CELEBRATION) } returns
             VisualMotivationAsset("Just", "Monika", ImageDimension(69, 420)).toOptional()
-        every { AudibleAssetDefinitionService.getRandomAssetByCategory(WaifuAssetCategory.CELEBRATION) } returns
+        every { AudibleAssetDefinitionService.getRandomUngroupedAssetByCategory(WaifuAssetCategory.CELEBRATION) } returns
             AudibleMotivationAsset(Paths.get("just", "monika")).toOptional()
 
         val maybeMotivationAsset = VisualMotivationAssetProvider.createAssetByCategory(WaifuAssetCategory.CELEBRATION)


### PR DESCRIPTION
# Motivation

Closes #278 

I thought that it was weird that as I was adding more grouped assets that it was choosing to play audio assets outside if it's group.

# Notes

I would like this to be part of the next release, before I start to group a bunch of audio with a bunch of assets in the fancy new `Waifu Asset Management` UI!


> Sneak peek

![image](https://user-images.githubusercontent.com/15972415/99862360-07579580-2b5f-11eb-9987-9f61fe5ebaf9.png)
