### PR TITLE
fix: not attempting to show motivation for disposed projects

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/MotivationFactory.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/MotivationFactory.kt
@@ -94,8 +94,10 @@ object MotivationFactory {
         motivationConstructor: (MotivationAsset) -> WaifuMotivation,
         assetSupplier: () -> Optional<MotivationAsset>
     ) {
+        val project = motivationEvent.project
+        if (project.isDisposed) return
+
         ApplicationManager.getApplication().executeOnPooledThread {
-            val project = motivationEvent.project
             assetSupplier()
                 .doOrElse({ asset ->
                     val motivation =


### PR DESCRIPTION
# Motivation

Closes #280

So I just fixed the symptom of the issue and did not address the underlying issue.
I think we may need to re-visit how the listeners are disposed on project close. 
That way we don't have motivation events with disposed projects in the first place :100:
