### PR TITLE
fix: new user on-boarding errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ intellij {
 
     alternativeIdePath idePath
 
-    setPlugins('io.unthrottled.amii:0.5.1')
+    setPlugins('io.unthrottled.amii:0.8.2')
 }
 
 compileKotlin {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v2.0.1](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v2.0.1)
+
+🐛 Bug Fixes:
+
+* [WMP-304](https://github.com/waifu-motivator/waifu-motivator-plugin/issues/304) Fixed new user on-boarding on the 2021.1 Builds.
+
 ## [v2.0](https://github.com/waifu-motivator/waifu-motivator-plugin/releases/tag/v2.0)
 
 #### 01/02/2020

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,7 @@ untilBuildVersion=211.*
 #
 pluginGroup=zd-zero
 pluginName_=waifu-motivator-plugin
-pluginVersion=2.0
-
-pluginSinceBuild=202
-pluginUntilBuild=203.*
+pluginVersion=2.0.1
 
 # This property allows you to run/develop the plugin on a different IDE
 # e.g.: idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6250.10

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
@@ -20,7 +20,7 @@ val UPDATE_MESSAGE: String =
     """
       What's New?<br>
       <ul>
-        <li>Migrated all notifications to <a href="https://github.com/Unthrottled/AMII">The Anime Meme Plugin</a></li>
+        <li>Fixed new user on-boarding issues in the 2021.1 build</li>
       </ul>
       <br>Please see the <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md">changelog</a> for more details.
       <br><br>


### PR DESCRIPTION
## Changes

- Grabbing the parent window for the ani-meme dialog on the EDT thread because it really didn't like it happening on one of the pooled applicaiton threads.

## Motivation

Closes #304 

## Notes

Apparently this has been happening for a while now. 

![Whoopsies](https://media1.tenor.com/images/8a6fc1bf54e933f9699df7bbbfb8fe19/tenor.gif?itemid=7976025)

I didn't notice because the Sentry errors weren't very helpful in notifying me that there was an issue in the EAP builds (I'll have to look into that)

Any users that have encountered this issue will be given the v2.0 migration dialog window. Which I don't think is that big of a deal, it accomplishes the same thing. It just assumes the user had used the old notification system before.

I tested this on both `2020.3.3` and `2021.1` and the on-boarding works!