### PR TITLE
fix: canary deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [ push, pull_request ]
+on:
+  push:
+    branches:
+      - main
+      - canary/*
+      - release/*
+  pull_request:
 
 jobs:
 
@@ -106,7 +112,7 @@ jobs:
 
       # Upload plugin artifact to make it available in the next jobs
       - name: Upload artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: plugin-artifact
           path: ./build/distributions/${{ steps.properties.outputs.artifact }}

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -8,17 +8,13 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    # FIXME: This is a temporary fix for deprecated commands
-    # see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
-    env:
-      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v1
         with:
           java-version: 11
       - name: Setting up environment
-        uses: waifu-motivator/wmp-env-action@v1.0.0
+        uses: waifu-motivator/wmp-env-action@v1.3.1
         with:
           release-type: non-prod
       - run: ./ciScripts/buildPlugin.sh

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ plugins {
 apply plugin: "org.jetbrains.changelog"
 
 group pluginGroup
-version pluginVersion
+version System.getenv().getOrDefault("VERSION", pluginVersion)
 
 sourceCompatibility = 1.8
 


### PR DESCRIPTION
This PR resolves #326.

Removed the insecure env setup and use [`wmp-env-action@1.3.1`](https://github.com/waifu-motivator/wmp-env-action/releases/tag/v1.3.1)