### PR TITLE
chore: 2021.2 build support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,7 @@ intellij {
     type.set(properties("platformType"))
     downloadSources.set(properties("platformDownloadSources").toBoolean())
 
-    plugins.set(Collections.singletonList('io.unthrottled.amii:0.10.2'))
+    plugins.set(Collections.singletonList('io.unthrottled.amii:0.10.6'))
 
     println "Building for IntelliJ version: ${version}"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,10 +8,10 @@ untilBuildVersion = 212.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.2, 2020.2.3, 2020.3.2
+pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1
 
 platformType = IC
-platformVersion = 2020.2.4
+platformVersion = LATEST-EAP-SNAPSHOT
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
@@ -55,7 +55,7 @@ class ErrorReporter : ErrorReportSubmitter() {
         events: Array<out IdeaLoggingEvent>,
         additionalInfo: String?,
         parentComponent: Component,
-        consumer: Consumer<SubmittedReportInfo>
+        consumer: Consumer<in SubmittedReportInfo>
     ): Boolean {
         ApplicationManager.getApplication()
             .executeOnPooledThread {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/promotion/MemePromotionDialog.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/promotion/MemePromotionDialog.kt
@@ -3,7 +3,7 @@ package zd.zero.waifu.motivator.plugin.promotion
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.installAndEnable
 import com.intellij.ui.JBColor
 import com.intellij.ui.layout.panel
 import com.intellij.util.ui.UIUtil
@@ -93,10 +93,8 @@ class AniMemePromotionDialog(
             }
 
             override fun actionPerformed(e: ActionEvent) {
-                PluginsAdvertiser.installAndEnable(
-                    setOf(
-                        PluginId.getId(AMII_PLUGIN_ID)
-                    )
+                installAndEnable(
+                    setOf(PluginId.getId(AMII_PLUGIN_ID))
                 ) {
                     close(INSTALLED_EXIT_CODE, true)
                 }
@@ -104,7 +102,7 @@ class AniMemePromotionDialog(
         }
     }
 
-    override fun createCenterPanel(): JComponent? {
+    override fun createCenterPanel(): JComponent {
         val promotionPane = buildPromotionPane()
         return panel {
             row {
@@ -201,60 +199,56 @@ class AniMemePromotionDialog(
         else existingUserPromotion()
     }
 
+    @Language("HTML")
     private fun newUserPromotion(): String {
         val promotionAssetURL = promotionAssets.promotionAssetURL
 
-        @Language("HTML")
-        val html =
-            """
-            <h2 class='header'>Your new virtual companion!</h2>
-      <div style='margin: 8px 0 0 100px'>
-        <p>
-          <a href='https://plugins.jetbrains.com/plugin/15865-amii'>The Anime Meme plugin</a>
-          gives your IDE more personality by using anime memes. <br/> You will get an assistant that will interact
-          with you as you build code.
-          <br/>Such as when your programs fail to run or tests pass/fail. Your companion<br/>
-          has the ability to react to these events. Which will most likely take the form <br/> of a reaction gif of
-          your favorite character(s)!
-        </p>
-      </div>
-      <br/>
-      <h3 class='info-foreground'>Bring Anime Memes to your IDE today!</h3>
-      <div class='display-image'><img src='$promotionAssetURL' height="150"/></div>
-      <br/>
-            """.trimIndent()
-        return html
+        return """
+        <h2 class='header'>Your new virtual companion!</h2>
+  <div style='margin: 8px 0 0 100px'>
+    <p>
+      <a href='https://plugins.jetbrains.com/plugin/15865-amii'>The Anime Meme plugin</a>
+      gives your IDE more personality by using anime memes. <br/> You will get an assistant that will interact
+      with you as you build code.
+      <br/>Such as when your programs fail to run or tests pass/fail. Your companion<br/>
+      has the ability to react to these events. Which will most likely take the form <br/> of a reaction gif of
+      your favorite character(s)!
+    </p>
+  </div>
+  <br/>
+  <h3 class='info-foreground'>Bring Anime Memes to your IDE today!</h3>
+  <div class='display-image'><img src='$promotionAssetURL' height="150"/></div>
+  <br/>
+        """.trimIndent()
     }
 
+    @Language("HTML")
     private fun existingUserPromotion(): String {
-        @Language("HTML")
-        val html =
-            """
-            <h2 class='header'>A brand new experience!</h2>
-      <div style='margin: 8px 0 0 100px'>
-        <p>
-          As of Waifu Motivator v2.0, notifications have been moved to
+        return """
+        <h2 class='header'>A brand new experience!</h2>
+  <div style='margin: 8px 0 0 100px'>
+    <p>
+      As of Waifu Motivator v2.0, notifications have been moved to
 <a href='https://plugins.jetbrains.com/plugin/15865-amii'>the Anime Meme</a> plugin. <br><br>
-          <div>Whats better?<br/>
-            <ul>
-                <li>More Content!</li>
-                <li>More Customization!</li>
-            </ul>
-          Breaking Changes:
-            <ul>
-                <li>Removed titled notifications.</li>
-                <li>Your previous configurations will be lost (Sorry!).</li>
-            </ul>
-            </div>
-          For a list of more breaking changes and enhancements please see
-          <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md">the changelog</a>
-        </p>
-      </div>
-      <br/>
-      <h3 class='info-foreground'>I hope you enjoy!</h3>
-      <br/>
-            """.trimIndent()
-        return html
+      <div>Whats better?<br/>
+        <ul>
+            <li>More Content!</li>
+            <li>More Customization!</li>
+        </ul>
+      Breaking Changes:
+        <ul>
+            <li>Removed titled notifications.</li>
+            <li>Your previous configurations will be lost (Sorry!).</li>
+        </ul>
+        </div>
+      For a list of more breaking changes and enhancements please see
+      <a href="https://github.com/waifu-motivator/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md">the changelog</a>
+    </p>
+  </div>
+  <br/>
+  <h3 class='info-foreground'>I hope you enjoy!</h3>
+  <br/>
+        """.trimIndent()
     }
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,6 @@
     ]]></description>
 
   <depends>com.intellij.modules.platform</depends>
-  <depends optional="true" config-file="zd.zero.waifu-motivator-plugin-io.unthrottled.amii.xml">io.unthrottled.amii</depends>
 
   <!--    Leave this in here so the IDE gives you feedback on-->
   <!--    What APIs are available-->

--- a/src/main/resources/META-INF/zd.zero.waifu-motivator-plugin-io.unthrottled.amii.xml
+++ b/src/main/resources/META-INF/zd.zero.waifu-motivator-plugin-io.unthrottled.amii.xml
@@ -1,2 +1,0 @@
-<idea-plugin>
-</idea-plugin>


### PR DESCRIPTION
This PR resolves #314 

Adds support for IJ 2021.2 and drops the explicit [optional dependency](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html) to `io.unthrottled.amii` as we're not using any extension points, but this doesn't mean that the integration of Anime Memes (AMII) is removed, for it fails on `runPluginVerifier` tasks.

Tested installing this without the `zd.zero.waifu-motivator-plugin-io.unthrottled.amii.xml` file, and it still works fine.