### PR TITLE
fix: release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v2
         with:
+          distribution: zulu
           java-version: 11
       - run: ./ciScripts/buildPlugin.sh
         env:
-          RELEASE_NOTES: ${{ github.event.release.body }}
           VERSION: ${{ github.ref }}
-      - name: Copy zip file
+      - name: Copy zip file for Github release
         run: cp build/distributions/*.zip waifu-motivator.zip
       - uses: actions/upload-release-asset@v1
         env:


### PR DESCRIPTION
Fix incompatible `actions/setup-java@v1` for Gradle `7.0.2`.