### PR TITLE
fix: buildPlugin duplicate handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ jobs:
           distribution: zulu
           java-version: 11
       - run: ./ciScripts/buildPlugin.sh
-        env:
-          VERSION: ${{ github.ref }}
       - name: Copy zip file for Github release
         run: cp build/distributions/*.zip waifu-motivator.zip
       - uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Fix issues with Gradle `buildPlugin` task

```
Entry waifu-motivator-plugin/lib/v2.1.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.1.1/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.
```