### PR TITLE
fix: publishPlugin release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,22 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - name: Setup java
+        uses: actions/setup-java@v2
         with:
           distribution: zulu
           java-version: 11
-      - run: ./ciScripts/buildPlugin.sh
+      - name: Fetch Sources
+        uses: actions/checkout@v2.3.4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Publish Plugin
+        run: ./gradlew publishPlugin
+        env:
+          VERSION: ${{ github.ref }}
+          # empty channel for default
+          PUBLISH_CHANNEL:
+          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
       - name: Copy zip file for Github release
         run: cp build/distributions/*.zip waifu-motivator.zip
       - uses: actions/upload-release-asset@v1
@@ -22,12 +32,6 @@ jobs:
           asset_path: waifu-motivator.zip
           asset_name: waifu-motivator.zip
           asset_content_type: application/zip
-      - run: ./gradlew publishPlugin
-        env:
-          VERSION: ${{ github.ref }}
-          # empty channel for default
-          PUBLISH_CHANNEL:
-          PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
 
   # Patch changelog, commit and push to the current repository
   changelog:


### PR DESCRIPTION
Fix issues with the `buildPlugin` that is part of the `publishPlugin` which finds duplicates of the built jar.

```
> Task :buildPlugin FAILED
FAILURE: Build failed with an exception.


Deprecated Gradle features were used in this build, making it incompatible with Gradle 8.0.
* What went wrong:

Execution failed for task ':buildPlugin'.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
> Entry waifu-motivator-plugin/lib/v2.1.jar is a duplicate but no duplicate handling strategy has been set. Please refer to https://docs.gradle.org/7.1.1/dsl/org.gradle.api.tasks.Copy.html#org.gradle.api.tasks.Copy:duplicatesStrategy for details.


See https://docs.gradle.org/7.1.1/userguide/command_line_interface.html#sec:command_line_warnings
* Try:
13 actionable tasks: 9 executed, 4 up-to-date
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 41s
Error: Process completed with exit code 1.
```