### PR TITLE
fix: incompatible dependencies to 2021.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [2.1.1]
 
 ### Added
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,22 +1,22 @@
 
 pluginGroup = zd-zero
 pluginName = waifu-motivator-plugin
-pluginVersion = 2.1.1
+pluginVersion = 2.1.2
 #
 sinceBuildVersion = 202.6397.94
 untilBuildVersion = 212.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.1.1
+pluginVerifierIdeVersions = 2020.2.4, 2020.3.4, 2021.2
 
 platformType = IC
-platformVersion = LATEST-EAP-SNAPSHOT
+platformVersion = 2020.2.4
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
-platformPlugins =
+platformPlugins=
 
 # This property allows you to run/develop the plugin on a different IDE
 # e.g.: idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6250.10

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
@@ -55,7 +55,7 @@ class ErrorReporter : ErrorReportSubmitter() {
         events: Array<out IdeaLoggingEvent>,
         additionalInfo: String?,
         parentComponent: Component,
-        consumer: Consumer<in SubmittedReportInfo>
+        consumer: Consumer<SubmittedReportInfo>
     ): Boolean {
         ApplicationManager.getApplication()
             .executeOnPooledThread {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/promotion/MemePromotionDialog.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/promotion/MemePromotionDialog.kt
@@ -3,7 +3,7 @@ package zd.zero.waifu.motivator.plugin.promotion
 import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.ui.DialogWrapper
-import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.installAndEnable
+import com.intellij.openapi.updateSettings.impl.pluginsAdvertisement.PluginsAdvertiser.installAndEnable
 import com.intellij.ui.JBColor
 import com.intellij.ui.layout.panel
 import com.intellij.util.ui.UIUtil


### PR DESCRIPTION
Even though the previous build properly installs in the IJ version `2021.2`. The IJ marketplace doesn't accept it and shows a conflict. Reverts to the platform target version `2020.2.4`.

![Screenshot from 2021-08-10 20-26-07](https://user-images.githubusercontent.com/21978370/128866469-28853d5a-7357-46ce-9eb0-5d70937ee11c.png)

~~Will merge and release this once `v2.1.2.beta.1fco11b95` is available in canary.~~
![Screenshot from 2021-08-10 22-31-57](https://user-images.githubusercontent.com/21978370/128886131-20a45b13-767f-469f-8a56-da20be11c60f.png)

